### PR TITLE
Use `defaultdict` to avoid hard coding buffer keys in `Concatenator` and `ConcatDataset`

### DIFF
--- a/ft_datasets/samsum_dataset.py
+++ b/ft_datasets/samsum_dataset.py
@@ -6,12 +6,11 @@
 import datasets
 from .utils import Concatenator
 
+
 def get_preprocessed_samsum(dataset_config, tokenizer, split):
     dataset = datasets.load_dataset("samsum", split=split)
 
-    prompt = (
-        f"Summarize this dialog:\n{{dialog}}\n---\nSummary:\n{{summary}}{{eos_token}}"
-    )
+    prompt = f"Summarize this dialog:\n{{dialog}}\n---\nSummary:\n{{summary}}{{eos_token}}"
 
     def apply_prompt_template(sample):
         return {

--- a/ft_datasets/samsum_dataset.py
+++ b/ft_datasets/samsum_dataset.py
@@ -23,9 +23,14 @@ def get_preprocessed_samsum(dataset_config, tokenizer, split):
         }
 
     dataset = dataset.map(apply_prompt_template, remove_columns=list(dataset.features))
-        
+
+    def preprocess_function(sample):
+        tokenized_output = tokenizer(sample["text"])
+        tokenized_output["labels"] = tokenized_output["input_ids"].copy()
+        return tokenized_output
+
     dataset = dataset.map(
-        lambda sample: tokenizer(sample["text"]),
+        preprocess_function,
         batched=True,
         remove_columns=list(dataset.features),
     ).map(Concatenator(), batched=True)

--- a/ft_datasets/utils.py
+++ b/ft_datasets/utils.py
@@ -35,8 +35,6 @@ class Concatenator(object):
             result = concatenated_samples
             self.residual = {k: [] for k in concatenated_samples.keys()}
 
-        result["labels"] = result["input_ids"].copy()
-
         return result
 
 class ConcatDataset(Dataset):

--- a/ft_datasets/utils.py
+++ b/ft_datasets/utils.py
@@ -1,60 +1,55 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
-from tqdm import tqdm
-from itertools import chain
 from collections import defaultdict
+from itertools import chain
+
 from torch.utils.data import Dataset
+from tqdm import tqdm
+
 
 class Concatenator(object):
     def __init__(self, chunk_size=2048):
-        self.chunk_size=chunk_size
-        self.residual =  defaultdict(list)
-        
+        self.chunk_size = chunk_size
+        self.residual = defaultdict(list)
+
     def __call__(self, batch):
-        concatenated_samples = {
-            k: self.residual[k] + list(chain(*v)) for k,v in batch.items()
-        }
+        concatenated_samples = {k: self.residual[k] + list(chain(*v)) for k, v in batch.items()}
 
         total_length = len(concatenated_samples[list(concatenated_samples.keys())[0]])
 
         if total_length >= self.chunk_size:
             chunk_num = total_length // self.chunk_size
             result = {
-                k: [
-                    v[i : i + self.chunk_size]
-                    for i in range(0, chunk_num * self.chunk_size, self.chunk_size)
-                ]
+                k: [v[i : i + self.chunk_size] for i in range(0, chunk_num * self.chunk_size, self.chunk_size)]
                 for k, v in concatenated_samples.items()
             }
-            self.residual = {
-                k: v[(chunk_num * self.chunk_size) :]
-                for k, v in concatenated_samples.items()
-            }
+            self.residual = {k: v[(chunk_num * self.chunk_size) :] for k, v in concatenated_samples.items()}
         else:
             result = concatenated_samples
             self.residual = {k: [] for k in concatenated_samples.keys()}
 
         return result
 
+
 class ConcatDataset(Dataset):
     def __init__(self, dataset, chunk_size=4096):
         self.dataset = dataset
         self.chunk_size = chunk_size
-        
+
         self.samples = []
 
         buffer = defaultdict(list)
-        
+
         for sample in tqdm(self.dataset, desc="Preprocessing dataset"):
-            buffer = {k: buffer[k] + v for k,v in sample.items()}
-            
+            buffer = {k: buffer[k] + v for k, v in sample.items()}
+
             while len(next(iter(buffer.values()))) > self.chunk_size:
-                self.samples.append({k: v[:self.chunk_size] for k,v in buffer.items()})
-                buffer = {k: v[self.chunk_size:] for k,v in buffer.items()}
-                
+                self.samples.append({k: v[: self.chunk_size] for k, v in buffer.items()})
+                buffer = {k: v[self.chunk_size :] for k, v in buffer.items()}
+
     def __getitem__(self, idx):
         return self.samples[idx]
-    
+
     def __len__(self):
         return len(self.samples)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please include a good title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

-->

<!-- Remove if not applicable -->

Use `defaultdict` to avoid hard coding buffer keys in `Concatenator` and `ConcatDataset`.

<!--
## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B
-->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
