### PR TITLE
Fix finetuning batch size

### DIFF
--- a/llama_finetuning.py
+++ b/llama_finetuning.py
@@ -180,7 +180,7 @@ def main(**kwargs):
     # Create DataLoaders for the training and validation dataset
     train_dataloader = torch.utils.data.DataLoader(
         dataset_train,
-        batch_size=train_config.batch_size_training,
+        batch_size=train_config.micro_batch_size,
         num_workers=train_config.num_workers_dataloader,
         pin_memory=True,
         sampler=train_sampler if train_sampler else None,


### PR DESCRIPTION
# Fix batch size in llama_finetuning.py

Currently, `llama_finetuning.py` uses `train_config.batch_size_training` as the batch size in the dataloader. This works fine right now, because the default config sets `batch_size_training` == `micro_batch_size` == `4`. But let's say you wanted an effecttive batch size of 128 and a micro batch size of 16. Then:
1. The dataloader would provide batches of 128 instead of 16
2. Gradient accumulation would happen ever (128 * 8) samples instead of every 128 samples
3. We would be loading 128 samples into memory each time, instead of 16

This PR fixes that issue.

Fixes # (issue)


## Feature/Issue validation/testing
I tested this by running the script with alpaca on an H100 - please let me know if theres anything more to be done.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
