### PR TITLE
fix a bug in the config for use_fast_kernels

### DIFF
--- a/configs/training.py
+++ b/configs/training.py
@@ -33,7 +33,7 @@ class train_config:
     dist_checkpoint_root_folder: str="PATH/to/save/FSDP/model" # will be used if using FSDP
     dist_checkpoint_folder: str="fine-tuned" # will be used if using FSDP
     save_optimizer: bool=False # will be used if using FSDP
-    use_fast_kernels: bool = False, # Enable using SDPA from PyTroch Accelerated Transformers, make use Flash Attention and Xformer memory-efficient kernels
+    use_fast_kernels: bool = False # Enable using SDPA from PyTroch Accelerated Transformers, make use Flash Attention and Xformer memory-efficient kernels
 
     
     


### PR DESCRIPTION
# What does this PR do?

There was a trailing comma in the existing config that was causing the bool to get picked up as a tuple:

```
In [3]: training.train_config
Out[3]: configs.training.train_config

In [4]: training.train_config.use_fast_kernels
Out[4]: (False,)
```

This tuple was interpreted as non-False and so the fine-tuning script was runninng with BetterTransformers even when not enabled.

```
In [5]: if training.train_config.use_fast_kernels:
   ...:     print("blah")
   ...:
blah
```

in a tuning run this was leading to unexpected errors:
```
  File "/workspace/llama-recipes/llama_finetuning.py", line 109, in main
    model = BetterTransformer.transform(model) 
  File "/opt/conda/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/opt/conda/lib/python3.10/site-packages/optimum/bettertransformer/transformation.py", line 211, in transform
    raise NotImplementedError(
NotImplementedError: The model type llama is not yet supported to be used with BetterTransformer. Feel free to open an issue at https://github.com/huggingface/optimum/issues if you would like this model type to be supported. Currently supported models are: dict_keys(['albert', 'bart', 'bert', 'bert-generation', 'blenderbot', 'camembert', 'clip', 'codegen', 'data2vec-text', 'deit', 'distilbert', 'electra', 'ernie', 'fsmt', 'gpt2', 'gptj', 'gpt_neo', 'gpt_neox', 'hubert', 'layoutlm', 'm2m_100', 'marian', 'markuplm', 'mbart', 'opt', 'pegasus', 'rembert', 'prophetnet', 'roberta', 'roc_bert', 'roformer', 'splinter', 'tapas', 't5', 'vilt', 'vit', 'vit_mae', 'vit_msn', 'wav2vec2', 'whisper', 'xlm-roberta', 'yolos']).
Traceback (most recent call last):
```

after this change:
```
>>> training.train_config.use_fast_kernels
False
>>>
```



## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
