### PR TITLE
The tokenizer will not add eos_token by default

### DIFF
--- a/src/llama_recipes/inference/chat_utils.py
+++ b/src/llama_recipes/inference/chat_utils.py
@@ -44,7 +44,7 @@ def format_tokens(dialogs, tokenizer):
             [
                 tokenizer.encode(
                     f"{B_INST} {(prompt['content']).strip()} {E_INST} {(answer['content']).strip()} ",
-                )
+                ) + [tokenizer.eos_token_id]
                 for prompt, answer in zip(dialog[::2], dialog[1::2])
             ],
             [],


### PR DESCRIPTION
# Add eos_token

The tokenizer will not add eos_token by default.
I think the [implementation from Huggingface](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/tokenization_llama.py#L382) is more reasonable.

## Issue validation
- Test A
```
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-chat-hf")
print(format_tokens([[
        {"role": "system", "content": "Always answer with Haiku"},
        {"role": "user", "content": "I am going to Paris, what should I see?"},
        {"role": "assistant", "content": "Haiku"},
        {"role": "user", "content": "How are you?"}
    ]], tokenizer))
```
The output is
```
[[1, 518, 25580, 29962, 3532, 14816, 29903, 6778, 13, 2499, 1994, 1234, 411, 5952, 18282, 13, 29966, 829, 14816, 29903, 6778, 13, 13, 29902, 626, 2675, 304, 3681, 29892, 825, 881, 306, 1074, 29973, 518, 29914, 25580, 29962, 5952, 18282, 29871, 1, 518, 25580, 29962, 1128, 526, 366, 29973, 518, 29914, 25580, 29962]]
```
which does not include any `eos_token_id`(2)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

