### PR TITLE
LoRa Config parameter flowthrough fix

### DIFF
--- a/src/llama_recipes/configs/peft.py
+++ b/src/llama_recipes/configs/peft.py
@@ -1,14 +1,14 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
-from dataclasses import dataclass
-from typing import ClassVar, List
+from dataclasses import dataclass, field
+from typing import List
 
 @dataclass
 class lora_config:
      r: int=8
      lora_alpha: int=32
-     target_modules: ClassVar[List[str]]= ["q_proj", "v_proj"]
+     target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
      bias= "none"
      task_type: str= "CAUSAL_LM"
      lora_dropout: float=0.05

--- a/src/llama_recipes/utils/config_utils.py
+++ b/src/llama_recipes/utils/config_utils.py
@@ -2,8 +2,7 @@
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
 import inspect
-from dataclasses import fields
-
+from dataclasses import asdict
 from peft import (
     LoraConfig,
     AdaptionPromptConfig,
@@ -45,7 +44,7 @@ def generate_peft_config(train_config, kwargs):
     config = configs[names.index(train_config.peft_method)]()
     
     update_config(config, **kwargs)
-    params = {k.name: getattr(config, k.name) for k in fields(config)}
+    params = asdict(config)
     peft_config = peft_configs[names.index(train_config.peft_method)](**params)
     
     return peft_config


### PR DESCRIPTION
# Fix to ensure that LoRa config parameters are not excluded

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please include a good title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

-->

<!-- Remove if not applicable -->

## Feature/Issue validation/testing

The current LoRa config includes a `ClassVar` containing a list of the target modules.  The config is parsed out using dataclasses `fields` to get the typed parameters from the config.  However, `fields` excludes ClassVars, so target_modules or other similarly implemented parameters in the configs are excluded.

#### Current implementation
```
>>> from typing import ClassVar, List
>>> from dataclasses import fields, dataclass
>>> 
>>> @dataclass
... class lora_config:
...    ...
...     target_modules: ClassVar[List[str]] = ("q_proj", "v_proj")
...    ... # other params
... 
>>> params = {k.name: getattr(lora_config, k.name) for k in fields(lora_config)}
>>> print(params)
{'r': 8, 'lora_alpha': 32, 'task_type': 'CAUSAL_LM', 'lora_dropout': 0.05, 'inference_mode': False}
```

#### Proposed fix
```
>>> from dataclasses import dataclass, field, asdict
>>> from typing import List
>>> 
>>> @dataclass
... class lora_config:
...     ... 
...     target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
...    ... # other params
... 
>>> params = asdict(lora_config())
>>> print(params)
{'r': 8, 'lora_alpha': 32, 'target_modules': ['q_proj', 'v_proj'], 'task_type': 'CAUSAL_LM', 'lora_dropout': 0.05, 'inference_mode': False}
```

This behavior is stated in the python documentation for fields in dataclasses [here](https://docs.python.org/3/library/dataclasses.html#class-variables).

I have also confirmed that this works in flowing through the config all the way into the LoraConfig, and the training script runs properly.

```
>>> from peft import LoraConfig
>>> 
>>> params = asdict(lora_config())
>>> config = LoraConfig(**params)
>>> print(config)
LoraConfig(peft_type=<PeftType.LORA: 'LORA'>, auto_mapping=None, base_model_name_or_path=None, revision=None, task_type='CAUSAL_LM', inference_mode=False, r=8, target_modules=['q_proj', 'v_proj'], lora_alpha=32, lora_dropout=0.05, fan_in_fan_out=False, bias='none', modules_to_save=None, init_lora_weights=True, layers_to_transform=None, layers_pattern=None)
```

This PR also includes a small typo fix.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?

Thanks for contributing 🎉!
