### PR TITLE
Pass `use_cache=False` when training with FSDP

### DIFF
--- a/llama_finetuning.py
+++ b/llama_finetuning.py
@@ -66,6 +66,7 @@ def main(**kwargs):
         setup_environ_flags(rank)
 
     # Load the pre-trained model and setup its configuration
+    use_cache = False if train_config.enable_fsdp else None
     if train_config.enable_fsdp and train_config.low_cpu_fsdp:
         """
         for FSDP, we can save cpu memory by loading pretrained model on rank0 only.
@@ -83,9 +84,11 @@ def main(**kwargs):
                 train_config.model_name,
                 load_in_8bit=True if train_config.quantization else None,
                 device_map="auto" if train_config.quantization else None,
+                use_cache=use_cache,
             )
         else:
             llama_config = LlamaConfig.from_pretrained(train_config.model_name)
+            llama_config.use_cache = use_cache
             with torch.device("meta"):
                 model = LlamaForCausalLM(llama_config)
 
@@ -94,6 +97,7 @@ def main(**kwargs):
             train_config.model_name,
             load_in_8bit=True if train_config.quantization else None,
             device_map="auto" if train_config.quantization else None,
+            use_cache=use_cache,
         )
     if train_config.enable_fsdp and train_config.use_fast_kernels:
         """


### PR DESCRIPTION
# What does this PR do?

This PR passes `use_cache=False` if using FSDP (since the default is [`True`](https://github.com/huggingface/transformers/blob/aea761499f4b1193f2706f471442da6f9df65d65/src/transformers/models/llama/configuration_llama.py#L120)). The current implementation assumes that FSDP is only used for training (i.e. not inference), in which case we do not need to cache past key/value states. For the LLaMA-7B run, this saves ~4 GB in activation memory and avoids peak memory from being at the end of the forward pass without affecting the end-to-end time.


<details>
<summary> Before (use_cache=True) </summary>

<img width="828" alt="snapshot_7b_perparam_8gpus" src="https://github.com/facebookresearch/llama-recipes/assets/31054793/dc1a8e39-eec2-41b9-a8c2-53300eec5c4d">
Note the peak memory at the end of forward. This happens because we are saving past key/value states that are not needed for gradient computation.

- Peak active: 14.93 GB
- Peak reserved: 19.52 GB
(The numbers from a prototype FSDP implementation, but existing FSDP shows a similar decrease since we only change the activation memory.)

</details>

<details>
<summary> After (use_cache=False) </summary>

<img width="790" alt="snapshot_7b_perparam_8gpus" src="https://github.com/facebookresearch/llama-recipes/assets/31054793/f99e0270-fb4a-4b36-80b4-c94e9700d569">

- Peak active: 10.94 GB
- Peak reserved: 15.11 GB

</details>





## Feature/Issue validation/testing

```
torchrun --nnodes 1 --nproc_per_node 8  llama_finetuning.py --enable_fsdp --model_name llama-2-7b-hf/ --pure_bf16 --output_dir output_dir --use_fast_kernels
```


Feel free to take over this PR and test further.