### PR TITLE
Make tests run on cpu instance

### DIFF
--- a/tests/test_finetuning.py
+++ b/tests/test_finetuning.py
@@ -83,12 +83,14 @@ def test_finetuning_peft(step_lr, optimizer, get_peft_model, gen_peft_config, ge
 @patch('llama_recipes.finetuning.get_preprocessed_dataset')
 @patch('llama_recipes.finetuning.get_peft_model')
 @patch('llama_recipes.finetuning.StepLR')
-def test_finetuning_weight_decay(step_lr, get_peft_model, get_dataset, tokenizer, get_model, train):
+def test_finetuning_weight_decay(step_lr, get_peft_model, get_dataset, tokenizer, get_model, train, mocker):
     kwargs = {"weight_decay": 0.01}
     
     get_dataset.return_value = [1]
     
-    get_peft_model.return_value = Linear(1,1)
+    model = mocker.MagicMock(name="model")
+    model.parameters.return_value = Linear(1,1).parameters()
+    get_peft_model.return_value = model 
     get_peft_model.return_value.print_trainable_parameters=lambda:None
     main(**kwargs)
     

--- a/tests/test_train_utils.py
+++ b/tests/test_train_utils.py
@@ -1,17 +1,19 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
+from unittest.mock import patch
+
 import torch
 
 from llama_recipes.utils.train_utils import train
 
-def test_gradient_accumulation(mocker):
-    # import sys
-    # sys.path.append('/home/ubuntu/llama-recipes/')
+@patch("llama_recipes.utils.train_utils.MemoryTrace")
+def test_gradient_accumulation(mem_trace, mocker):
     
     model = mocker.MagicMock(name="model")
     model().loss.__truediv__().detach.return_value = torch.tensor(1)
-    batch = {"input": torch.zeros(1)}
+    mock_tensor = mocker.MagicMock(name="tensor")
+    batch = {"input": mock_tensor}
     train_dataloader = [batch, batch, batch, batch, batch]
     eval_dataloader = None
     tokenizer = mocker.MagicMock()


### PR DESCRIPTION
# What does this PR do?
This PR fixes the unit tests to not require a gpu torch.

Fixes # (issue)


## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] pytest tests/
```
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.10.13, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/ubuntu/llama-recipes
plugins: mock-3.11.1
collected 8 items

tests/test_finetuning.py ....                                                                                                                                                                                                         [ 50%]
tests/test_train_utils.py .                                                                                                                                                                                                           [ 62%]
tests/datasets/test_custom_dataset.py ..                                                                                                                                                                                              [ 87%]
tests/datasets/test_samsum_datasets.py .                                                                                                                                                                                              [100%]

============================================================================================================= warnings summary ==============================================================================================================
src/llama_recipes/finetuning.py:5
  /home/ubuntu/llama-recipes/src/llama_recipes/finetuning.py:5: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import packaging

../miniconda3/envs/llama/lib/python3.10/site-packages/bitsandbytes/cextension.py:34
  /home/ubuntu/miniconda3/envs/llama/lib/python3.10/site-packages/bitsandbytes/cextension.py:34: UserWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
    warn("The installed version of bitsandbytes was compiled without GPU support. "

../miniconda3/envs/llama/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8
  /home/ubuntu/miniconda3/envs/llama/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8: DeprecationWarning: torch.distributed._shard.checkpoint will be deprecated, use torch.distributed.checkpoint instead
    warnings.warn(

tests/datasets/test_samsum_datasets.py::test_custom_dataset
  /home/ubuntu/miniconda3/envs/llama/lib/python3.10/site-packages/dill/_dill.py:412: PicklingWarning: Cannot locate reference to <class 'unittest.mock.MagicMock'>.
    StockPickler.save(self, obj, save_persistent_id)

tests/datasets/test_samsum_datasets.py::test_custom_dataset
  /home/ubuntu/miniconda3/envs/llama/lib/python3.10/site-packages/dill/_dill.py:412: PicklingWarning: Cannot pickle <class 'unittest.mock.MagicMock'>: unittest.mock.MagicMock has recursive self-references that trigger a RecursionError.
    StockPickler.save(self, obj, save_persistent_id)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================================== 8 passed, 5 warnings in 20.95s =======================================================================================================
```

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [X] Did you write any new necessary tests?

Thanks for contributing 🎉!
