### PR TITLE
fix incorrect split of InstructionDataset

### DIFF
--- a/src/llama_recipes/datasets/alpaca_dataset.py
+++ b/src/llama_recipes/datasets/alpaca_dataset.py
@@ -27,7 +27,7 @@ class InstructionDataset(Dataset):
     def __init__(self, dataset_config, tokenizer, partition="train", max_words=30):
         self.ann = json.load(open(dataset_config.data_path))
         if partition == "train":
-            self.ann = self.ann
+            self.ann = self.ann[200:]
         else:
             self.ann = self.ann[:200]
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please include a good title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

-->

<!-- Remove if not applicable -->
`InstructionDataset` did not correctly split training set and test set, resulting in the test set being used for training.


## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Adapted from finetuning.py
```python
import fire
import os
import torch
import torch.distributed as dist
from torch.utils.data import DistributedSampler
from transformers import (
    LlamaTokenizer,
    default_data_collator,
)
from llama_recipes.configs import fsdp_config, train_config
from llama_recipes.utils.config_utils import (
    update_config,
    generate_dataset_config,
)
from llama_recipes.utils.train_utils import (
    setup,
    setup_environ_flags,
    clear_gpu_cache,
)
from llama_recipes.utils.dataset_utils import get_preprocessed_dataset

def register_hook(model: torch.nn.Module, name, hook):
    module_names = []
    for n, m in model.named_modules():
        if name in n:
            m.register_forward_hook(hook=hook)
            module_names.append(n)
    return module_names

def main(**kwargs):
    update_config((train_config, fsdp_config), **kwargs)
    if train_config.enable_fsdp:
        setup()
        # torchrun specific
        local_rank = int(os.environ["LOCAL_RANK"])
        rank = int(os.environ["RANK"])
        world_size = int(os.environ["WORLD_SIZE"])
    if torch.distributed.is_initialized():
        torch.cuda.set_device(local_rank)
        clear_gpu_cache(local_rank)
        setup_environ_flags(rank)
    
    dataset_config = generate_dataset_config(train_config, kwargs)

    tokenizer = LlamaTokenizer.from_pretrained(train_config.model_name)
    tokenizer.add_special_tokens(
            {

                "pad_token": "<PAD>",
            }
        )
    dataset_train = get_preprocessed_dataset(
        tokenizer,
        dataset_config,
        split="train",
    )
    dataset_val = get_preprocessed_dataset(
        tokenizer,
        dataset_config,
        split="test",
    )
    train_sampler = DistributedSampler(
        dataset_train,
        rank=dist.get_rank(),
        num_replicas=dist.get_world_size(),
        shuffle=True,
    )
    if train_config.run_validation:
        val_sampler = DistributedSampler(
            dataset_val,
            rank=dist.get_rank(),
            num_replicas=dist.get_world_size(),
        )
    train_dataloader = torch.utils.data.DataLoader(
        dataset_train,
        batch_size=train_config.batch_size_training,
        num_workers=train_config.num_workers_dataloader,
        pin_memory=True,
        sampler=train_sampler if train_sampler else None,
        drop_last=True,
        collate_fn=default_data_collator,
    )
    eval_dataloader = None
    if train_config.run_validation:
        eval_dataloader = torch.utils.data.DataLoader(
            dataset_val,
            batch_size=train_config.val_batch_size,
            num_workers=train_config.num_workers_dataloader,
            pin_memory=True,
            sampler=val_sampler if val_sampler else None,
            drop_last=True,
            collate_fn=default_data_collator,
        )
    
    eval_decoded = []
    for batch in eval_dataloader:
        decoded = tokenizer.decode(batch['input_ids'][0])
        eval_decoded.append(decoded)
    print(f'eval length: {len(eval_decoded)}')
    
    from tqdm import tqdm
    found_idx = []
    found_idx_reversed = []
    for idx, batch in enumerate(tqdm(train_dataloader)):
        decoded = tokenizer.decode(batch['input_ids'][0])
        if decoded in eval_decoded:
            print(f'found: {idx} ({-(len(train_dataloader) - idx)})')
            found_idx.append(idx)
            found_idx_reversed.append(-(len(train_dataloader) - idx))
    print(f'found_idx({len(found_idx)}): {found_idx}')
    print(f'found_idx_reversed({len(found_idx_reversed)}): {found_idx_reversed}')

if __name__ == '__main__':
    fire.Fire(main)

```
Logs for Test A
```
eval length: 200
100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 279444/279444 [13:36<00:00, 342.21it/s]
found_idx(0): []
found_idx_reversed(0): []
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?  (no need to update)
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
