### PR TITLE
Fix/unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ packages = ["src/llama_recipes"]
 
 [tool.hatch.metadata.hooks.requirements_txt]
 files = ["requirements.txt"]
+
+[tool.pytest.ini_options]
+markers = [
+    "skip_missing_tokenizer: skip tests when we can not access meta-llama/Llama-2-7b-hf on huggingface hub (Log in with `huggingface-cli login` to unskip).",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,18 @@ import pytest
 
 from transformers import LlamaTokenizer
 
+ACCESS_ERROR_MSG = "Could not access tokenizer at 'meta-llama/Llama-2-7b-hf'. Did you log into huggingface hub and provided the correct token?"
+
+unskip_missing_tokenizer = False
+
 @pytest.fixture(scope="module")
 def llama_tokenizer():
     try:
         return LlamaTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
-    except OSError:
-        return None
+    except OSError as e:
+        if unskip_missing_tokenizer:
+            raise e
+    return None
 
 
 @pytest.fixture
@@ -21,8 +27,24 @@ def setup_tokenizer(llama_tokenizer):
 
     return _helper
 
+
 @pytest.fixture(autouse=True)
 def skip_if_tokenizer_is_missing(request, llama_tokenizer):
-    if request.node.get_closest_marker("skip_missing_tokenizer"):
+    if request.node.get_closest_marker("skip_missing_tokenizer") and not unskip_missing_tokenizer:
         if llama_tokenizer is None:
-            pytest.skip("Llama tokenizer could not be accessed. Did you log into huggingface hub and provided the correct token?")
+            pytest.skip(ACCESS_ERROR_MSG)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--unskip-missing-tokenizer",
+        action="store_true",
+        default=False, help="disable skip missing tokenizer")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_cmdline_preparse(config, args):
+    if "--unskip-missing-tokenizer" not in args:
+        return
+    global unskip_missing_tokenizer
+    unskip_missing_tokenizer = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,24 @@ import pytest
 
 from transformers import LlamaTokenizer
 
+@pytest.fixture(scope="module")
+def llama_tokenizer():
+    try:
+        return LlamaTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+    except OSError:
+        return None
+
 
 @pytest.fixture
-def setup_tokenizer():
-    def _helper(tokenizer):
+def setup_tokenizer(llama_tokenizer):
+    def _helper(tokenizer_mock):
         #Align with Llama 2 tokenizer
-        tokenizer.from_pretrained.return_value = LlamaTokenizer.from_pretrained("decapoda-research/llama-7b-hf")
-        tokenizer.from_pretrained.return_value.add_special_tokens({'bos_token': '<s>', 'eos_token': '</s>'})
-        tokenizer.from_pretrained.return_value.bos_token_id = 1
-        tokenizer.from_pretrained.return_value.eos_token_id = 2
+        tokenizer_mock.from_pretrained.return_value = llama_tokenizer
 
     return _helper
+
+@pytest.fixture(autouse=True)
+def skip_if_tokenizer_is_missing(request, llama_tokenizer):
+    if request.node.get_closest_marker("skip_missing_tokenizer"):
+        if llama_tokenizer is None:
+            pytest.skip("Llama tokenizer could not be accessed. Did you log into huggingface hub and provided the correct token?")

--- a/tests/datasets/test_custom_dataset.py
+++ b/tests/datasets/test_custom_dataset.py
@@ -17,6 +17,7 @@ def check_padded_entry(batch):
     assert batch["input_ids"][0][-1] == 2
 
 
+@pytest.mark.skip_missing_tokenizer()
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')
@@ -29,7 +30,7 @@ def test_custom_dataset(step_lr, optimizer, get_model, tokenizer, train, mocker,
 
     kwargs = {
         "dataset": "custom_dataset",
-        "model_name": "decapoda-research/llama-7b-hf", # We use the tokenizer as a surrogate for llama2 tokenizer here
+        "model_name": "meta-llama/Llama-2-7b-hf",
         "custom_dataset.file": "examples/custom_dataset.py",
         "custom_dataset.train_split": "validation",
         "batch_size_training": 2,

--- a/tests/datasets/test_grammar_datasets.py
+++ b/tests/datasets/test_grammar_datasets.py
@@ -1,11 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
+import pytest
 from unittest.mock import patch
 
 from transformers import LlamaTokenizer
 
 
+@pytest.mark.skip_missing_tokenizer()
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')
@@ -18,7 +20,7 @@ def test_grammar_dataset(step_lr, optimizer, get_model, tokenizer, train, mocker
 
     BATCH_SIZE = 8
     kwargs = {
-        "model_name": "decapoda-research/llama-7b-hf",
+        "model_name": "meta-llama/Llama-2-7b-hf",
         "batch_size_training": BATCH_SIZE,
         "val_batch_size": 1,
         "use_peft": False,
@@ -46,8 +48,8 @@ def test_grammar_dataset(step_lr, optimizer, get_model, tokenizer, train, mocker
     assert "input_ids" in batch.keys()
     assert "attention_mask" in batch.keys()
 
-    assert batch["labels"][0][29] == -100
-    assert batch["labels"][0][30] == 29871
+    assert batch["labels"][0][31] == -100
+    assert batch["labels"][0][32] == 1152
 
     assert batch["input_ids"][0][0] == 1
     assert batch["labels"][0][-1] == 2

--- a/tests/datasets/test_samsum_datasets.py
+++ b/tests/datasets/test_samsum_datasets.py
@@ -1,10 +1,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
+import pytest
 from functools import partial
 from unittest.mock import patch
 
 
+@pytest.mark.skip_missing_tokenizer()
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')
@@ -17,7 +19,7 @@ def test_samsum_dataset(step_lr, optimizer, get_model, tokenizer, train, mocker,
 
     BATCH_SIZE = 8
     kwargs = {
-        "model_name": "decapoda-research/llama-7b-hf",
+        "model_name": "meta-llama/Llama-2-7b-hf",
         "batch_size_training": BATCH_SIZE,
         "val_batch_size": 1,
         "use_peft": False,
@@ -46,7 +48,7 @@ def test_samsum_dataset(step_lr, optimizer, get_model, tokenizer, train, mocker,
     assert "attention_mask" in batch.keys()
 
     assert batch["labels"][0][268] == -100
-    assert batch["labels"][0][269] == 22291
+    assert batch["labels"][0][269] == 319
 
     assert batch["input_ids"][0][0] == 1
     assert batch["labels"][0][-1] == 2

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import patch
 
 
+@pytest.mark.skip_missing_tokenizer()
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')
@@ -16,7 +17,7 @@ def test_packing(step_lr, optimizer, get_model, tokenizer, train, mocker, setup_
     setup_tokenizer(tokenizer)
 
     kwargs = {
-        "model_name": "decapoda-research/llama-7b-hf",
+        "model_name": "meta-llama/Llama-2-7b-hf",
         "batch_size_training": 8,
         "val_batch_size": 1,
         "use_peft": False,
@@ -46,6 +47,7 @@ def test_packing(step_lr, optimizer, get_model, tokenizer, train, mocker, setup_
     assert batch["attention_mask"][0].size(0) == 4096
 
 
+@pytest.mark.skip_missing_tokenizer()
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')
@@ -69,7 +71,7 @@ def test_distributed_packing(dist, is_initialized, fsdp, setup, step_lr, optimiz
     os.environ['MASTER_PORT'] = '12345'
 
     kwargs = {
-        "model_name": "decapoda-research/llama-7b-hf",
+        "model_name": "meta-llama/Llama-2-7b-hf",
         "batch_size_training": 8,
         "val_batch_size": 1,
         "use_peft": False,

--- a/tests/test_train_utils.py
+++ b/tests/test_train_utils.py
@@ -12,7 +12,7 @@ from llama_recipes.utils.train_utils import train
 @patch("llama_recipes.utils.train_utils.torch.cuda.amp.GradScaler")
 @patch("llama_recipes.utils.train_utils.torch.cuda.amp.autocast")
 def test_gradient_accumulation(autocast, scaler, nullcontext, mem_trace, mocker):
-    
+
     model = mocker.MagicMock(name="model")
     model().loss.__truediv__().detach.return_value = torch.tensor(1)
     mock_tensor = mocker.MagicMock(name="tensor")
@@ -27,7 +27,8 @@ def test_gradient_accumulation(autocast, scaler, nullcontext, mem_trace, mocker)
     train_config.enable_fsdp = False
     train_config.use_fp16 = False
     train_config.run_validation = False
-    
+    train_config.gradient_clipping = False
+
     train(
         model,
         train_dataloader,
@@ -38,15 +39,15 @@ def test_gradient_accumulation(autocast, scaler, nullcontext, mem_trace, mocker)
         gradient_accumulation_steps,
         train_config,
     )
-    
+
     assert optimizer.zero_grad.call_count == 5
     optimizer.zero_grad.reset_mock()
-    
+
     assert nullcontext.call_count == 5
     nullcontext.reset_mock()
-    
+
     assert autocast.call_count == 0
-    
+
     gradient_accumulation_steps = 2
     train_config.use_fp16 = True
     train(


### PR DESCRIPTION
# What does this PR do?
This PR removes our usage of decapoda-research/llama-7b-hf in the unit tests as a surrogate for the actual llama tokenizer. As an alternative we skip the tests if we can not access the gated model folder.

Fixes # (issue)


## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] Test A `pytest tests`
```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/mreso/llama-recipes
configfile: pyproject.toml
plugins: mock-3.12.0
collected 23 items

tests/test_batching.py ..                                                                                                                                                                                                              [  8%]
tests/test_finetuning.py .....                                                                                                                                                                                                         [ 30%]
tests/test_sampler.py ..........                                                                                                                                                                                                       [ 73%]
tests/test_train_utils.py .                                                                                                                                                                                                            [ 78%]
tests/datasets/test_alpaca_dataset.py s                                                                                                                                                                                                [ 82%]
tests/datasets/test_custom_dataset.py ..                                                                                                                                                                                               [ 91%]
tests/datasets/test_grammar_datasets.py .                                                                                                                                                                                              [ 95%]
tests/datasets/test_samsum_datasets.py .                                                                                                                                                                                               [100%]

============================================================================================================== warnings summary ==============================================================================================================
../.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:441
  /home/mreso/.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    _torch_pytree._register_pytree_node(

src/llama_recipes/finetuning.py:5
  /home/mreso/llama-recipes/src/llama_recipes/finetuning.py:5: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import packaging

../.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:309
../.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:309
  /home/mreso/.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    _torch_pytree._register_pytree_node(

../.conda/envs/llama/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8
  /home/mreso/.conda/envs/llama/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8: DeprecationWarning: torch.distributed._shard.checkpoint will be deprecated, use torch.distributed.checkpoint instead
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================= 22 passed, 1 skipped, 5 warnings in 48.58s =================================================================================================
```

- [X] Test B ```$huggingface-cli logout
Successfully logged out.
$rm -rf ~/.cache/huggingface/
$pytest tests```

```
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/mreso/llama-recipes
configfile: pyproject.toml
plugins: mock-3.12.0
collected 23 items

tests/test_batching.py ss                                                                                                                                                                                                              [  8%]
tests/test_finetuning.py .....                                                                                                                                                                                                         [ 30%]
tests/test_sampler.py ..........                                                                                                                                                                                                       [ 73%]
tests/test_train_utils.py .                                                                                                                                                                                                            [ 78%]
tests/datasets/test_alpaca_dataset.py s                                                                                                                                                                                                [ 82%]
tests/datasets/test_custom_dataset.py s.                                                                                                                                                                                               [ 91%]
tests/datasets/test_grammar_datasets.py s                                                                                                                                                                                              [ 95%]
tests/datasets/test_samsum_datasets.py s                                                                                                                                                                                               [100%]

============================================================================================================== warnings summary ==============================================================================================================
../.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:441
  /home/mreso/.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    _torch_pytree._register_pytree_node(

src/llama_recipes/finetuning.py:5
  /home/mreso/llama-recipes/src/llama_recipes/finetuning.py:5: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import packaging

../.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:309
../.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:309
  /home/mreso/.conda/envs/llama/lib/python3.10/site-packages/transformers/utils/generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    _torch_pytree._register_pytree_node(

../.conda/envs/llama/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8
  /home/mreso/.conda/envs/llama/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8: DeprecationWarning: torch.distributed._shard.checkpoint will be deprecated, use torch.distributed.checkpoint instead
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================= 17 passed, 6 skipped, 5 warnings in 8.32s ==================================================================================================
```
- [X] Test C `$pytest tests --unskip-missing-tokenizer`
```
========================================================================================================== short test summary info ===========================================================================================================
ERROR tests/test_batching.py::test_packing - OSError: You are trying to access a gated repo.
ERROR tests/test_batching.py::test_distributed_packing - OSError: You are trying to access a gated repo.
ERROR tests/test_finetuning.py::test_finetuning_no_validation - OSError: You are trying to access a gated repo.
ERROR tests/test_finetuning.py::test_finetuning_with_validation - OSError: You are trying to access a gated repo.
ERROR tests/test_finetuning.py::test_finetuning_peft - OSError: You are trying to access a gated repo.
ERROR tests/test_finetuning.py::test_finetuning_weight_decay - OSError: You are trying to access a gated repo.
ERROR tests/test_finetuning.py::test_batching_strategy - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_array[2-False] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_array[8-False] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_array[2-True] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_array[8-True] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_dict[2-False] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_dict[8-False] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_dict[2-True] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_batch_sampler_dict[8-True] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_dist_batch_sampling[2] - OSError: You are trying to access a gated repo.
ERROR tests/test_sampler.py::test_dist_batch_sampling[8] - OSError: You are trying to access a gated repo.
ERROR tests/test_train_utils.py::test_gradient_accumulation - OSError: You are trying to access a gated repo.
ERROR tests/datasets/test_custom_dataset.py::test_custom_dataset - OSError: You are trying to access a gated repo.
ERROR tests/datasets/test_custom_dataset.py::test_unknown_dataset_error - OSError: You are trying to access a gated repo.
ERROR tests/datasets/test_grammar_datasets.py::test_grammar_dataset - OSError: You are trying to access a gated repo.
ERROR tests/datasets/test_samsum_datasets.py::test_samsum_dataset - OSError: You are trying to access a gated repo.
================================================================================================= 1 skipped, 6 warnings, 22 errors in 9.18s ==================================================================================================
```
## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [X] Did you write any new necessary tests?

Thanks for contributing 🎉!
