### PR TITLE
Fix test_finetuning for env without cuda

### DIFF
--- a/tests/test_finetuning.py
+++ b/tests/test_finetuning.py
@@ -5,6 +5,7 @@ import pytest
 from pytest import approx
 from unittest.mock import patch
 
+import torch
 from torch.nn import Linear
 from torch.optim import AdamW
 from torch.utils.data.dataloader import DataLoader
@@ -100,8 +101,11 @@ def test_finetuning_weight_decay(step_lr, get_peft_model, get_dataset, tokenizer
     kwargs = {"weight_decay": 0.01}
 
     get_dataset.return_value = get_fake_dataset()
+    
+    model = mocker.MagicMock(name="Model")
+    model.parameters.return_value = [torch.ones(1,1)]
 
-    get_model.return_value = Linear(1,1)
+    get_model.return_value = model 
 
     main(**kwargs)
 


### PR DESCRIPTION
# What does this PR do?

This PR fixed test_finetuning.py for cpu only envs

## Feature/Issue validation/testing

- [X] Test A
```
$ nvidia-smi
NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure that the latest NVIDIA driver is installed and running.
$ python -m pytest tests/
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/ubuntu/llama-recipes
configfile: pyproject.toml
plugins: mock-3.12.0
collected 22 items

tests/test_batching.py ss                                                                                                                                                                                                              [  9%]
tests/test_finetuning.py .....                                                                                                                                                                                                         [ 31%]
tests/test_sampler.py ..........                                                                                                                                                                                                       [ 77%]
tests/test_train_utils.py .                                                                                                                                                                                                            [ 81%]
tests/datasets/test_custom_dataset.py s.                                                                                                                                                                                               [ 90%]
tests/datasets/test_grammar_datasets.py s                                                                                                                                                                                              [ 95%]
tests/datasets/test_samsum_datasets.py s                                                                                                                                                                                               [100%]

============================================================================================================== warnings summary ==============================================================================================================
tests/conftest.py:45
  /home/ubuntu/llama-recipes/tests/conftest.py:45: PytestRemovedIn8Warning: The pytest_cmdline_preparse hook is deprecated and will be removed in a future release.
  Please use pytest_load_initial_conftests hook instead.
    @pytest.hookimpl(tryfirst=True)

src/llama_recipes/finetuning.py:5
  /home/ubuntu/llama-recipes/src/llama_recipes/finetuning.py:5: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import packaging

../miniconda3/envs/llama-recipes/lib/python3.10/site-packages/torch/cuda/__init__.py:611
  /home/ubuntu/miniconda3/envs/llama-recipes/lib/python3.10/site-packages/torch/cuda/__init__.py:611: UserWarning: Can't initialize NVML
    warnings.warn("Can't initialize NVML")

../miniconda3/envs/llama-recipes/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8
  /home/ubuntu/miniconda3/envs/llama-recipes/lib/python3.10/site-packages/torch/distributed/_shard/checkpoint/__init__.py:8: DeprecationWarning: torch.distributed._shard.checkpoint will be deprecated, use torch.distributed.checkpoint instead
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================= 17 passed, 5 skipped, 4 warnings in 1.63s ==================================================================================================
```

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [X] Did you write any new necessary tests?

Thanks for contributing 🎉!
