### PR TITLE
Fix Anyscale API token URL in Purple_Llama_Anyscale.ipynb

### DIFF
--- a/examples/Purple_Llama_Anyscale.ipynb
+++ b/examples/Purple_Llama_Anyscale.ipynb
@@ -80,7 +80,7 @@
       "source": [
         "#### **3 - Using Purple Llama**\n",
         "\n",
-        "In this notebook, We will use the Llama Guard model managed by the [Anyscale Endpoints](https://app.endpoints.anyscale.com/) for inferencing. You'll need to first register an account with Anyscale [here](https://app.endpoints.anyscale.com) then obtain an Anyscale API key [here](https://api.together.xyz/settings/api-keys). Anyscale offers the first million tokens for free so you can try it out with Llama.\n"
+        "In this notebook, We will use the Llama Guard model managed by the [Anyscale Endpoints](https://app.endpoints.anyscale.com/) for inferencing. You'll need to first register an account with Anyscale [here](https://app.endpoints.anyscale.com) then obtain an Anyscale API key [here](https://app.endpoints.anyscale.com/console/credentials). Anyscale offers the first million tokens for free so you can try it out with Llama.\n"
       ]
     },
     {


### PR DESCRIPTION
This PR fixes a typo in the docs.

The previous URL linked for Anyscale was mistakenly pointing to a Together API keys URL.