### PR TITLE
Remove deprecated pytest_cmdline_preparse

### DIFF
--- a/tests/datasets/test_custom_dataset.py
+++ b/tests/datasets/test_custom_dataset.py
@@ -17,7 +17,7 @@ def check_padded_entry(batch):
     assert batch["input_ids"][0][-1] == 2
 
 
-@pytest.mark.skip_missing_tokenizer()
+@pytest.mark.skip_missing_tokenizer
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')

--- a/tests/datasets/test_grammar_datasets.py
+++ b/tests/datasets/test_grammar_datasets.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from transformers import LlamaTokenizer
 
 
-@pytest.mark.skip_missing_tokenizer()
+@pytest.mark.skip_missing_tokenizer
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')

--- a/tests/datasets/test_samsum_datasets.py
+++ b/tests/datasets/test_samsum_datasets.py
@@ -6,7 +6,7 @@ from functools import partial
 from unittest.mock import patch
 
 
-@pytest.mark.skip_missing_tokenizer()
+@pytest.mark.skip_missing_tokenizer
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import patch
 
 
-@pytest.mark.skip_missing_tokenizer()
+@pytest.mark.skip_missing_tokenizer
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')
@@ -47,7 +47,7 @@ def test_packing(step_lr, optimizer, get_model, tokenizer, train, mocker, setup_
     assert batch["attention_mask"][0].size(0) == 4096
 
 
-@pytest.mark.skip_missing_tokenizer()
+@pytest.mark.skip_missing_tokenizer
 @patch('llama_recipes.finetuning.train')
 @patch('llama_recipes.finetuning.LlamaTokenizer')
 @patch('llama_recipes.finetuning.LlamaForCausalLM.from_pretrained')


### PR DESCRIPTION
# What does this PR do?
This PR fixes the unit test for pytest 8.0 release by removing the deprecated pytest_cmdline_preparse hook

Fixes # (issue)


## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] pytest tests/test_batching.py
Tests get skipped if tokenizer is unavailable
```
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.10.13, pytest-8.0.0, pluggy-1.3.0
rootdir: /home/ubuntu/llama-recipes
configfile: pyproject.toml
plugins: mock-3.12.0
collected 2 items

tests/test_batching.py ss                                                                                                                                                                                                                              [100%]

====================================================================================================================== warnings summary ======================================================================================================================
../miniconda3/envs/llama-recipes/lib/python3.10/site-packages/transformers/utils/generic.py:441
  /home/ubuntu/miniconda3/envs/llama-recipes/lib/python3.10/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
    _torch_pytree._register_pytree_node(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================== 2 skipped, 1 warning in 0.13s ================================================================================================================
```
- [X] pytest tests/test_batching.py --unskip-missing-tokenizer
Tokenizer unavailable but we force it to unskip
 ```
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.10.13, pytest-8.0.0, pluggy-1.3.0
rootdir: /home/ubuntu/llama-recipes
configfile: pyproject.toml
plugins: mock-3.12.0
collected 2 items

tests/test_batching.py EE                                                                                                                                                                                                                              [100%]

=========================================================================================================================== ERRORS ===========================================================================================================================
_______________________________________________________________________________________________________________ ERROR at setup of test_packing __________________________________________________________________________________________________________
```


## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [X] Did you write any new necessary tests?

Thanks for contributing 🎉!
